### PR TITLE
Updated cpm/dose rate conversion factor

### DIFF
--- a/safecast_layer.py
+++ b/safecast_layer.py
@@ -207,7 +207,7 @@ class SafecastLayer(QgsVectorLayer):
 
         # compute ader_microSvh
         try:
-            ader = int(row[3]) * 0.0028571429
+            ader = int(row[3]) * 0.0029940119760479
         except ValueError:
             ader = -1
         row.insert(0, ader)


### PR DESCRIPTION
Replaced 0.0028571428571429 (e.g. 1/350) with 0.0029940119760479 (1/334)
following
"-- 2016-05-31 ND: bGeigie conversion /350.0 -> /334.0 per Pieter."
https://github.com/Safecast/safecastapi/blob/7cbf30add95b9616f0a3d13087e9f9404f78279e/script/ios_query.sql#L14