### PR TITLE
Prevent file saves *.log.LOG

### DIFF
--- a/safecast_dockwidget.py
+++ b/safecast_dockwidget.py
@@ -246,7 +246,7 @@ class SafecastDockWidget(QtGui.QDockWidget, FORM_CLASS):
             # action canceled
             return
 
-        if not filePath.endswith('.LOG'):
+        if not filePath.upper().endswith('.LOG'):
             # add missing extension if missing
             filePath += '.LOG'
 


### PR DESCRIPTION
I like to name my files with the extension .log. The current version of the plugin forces the uppercase version. This PR fixes that.